### PR TITLE
Add migrate for LXCA events

### DIFF
--- a/db/migrate/20161216131904_add_severity_to_event_streams.rb
+++ b/db/migrate/20161216131904_add_severity_to_event_streams.rb
@@ -1,0 +1,5 @@
+class AddSeverityToEventStreams < ActiveRecord::Migration[5.0]
+   def change
+     add_column :event_streams, :lxca_severity, :string
+   end
+ end

--- a/db/migrate/20161216132051_add_cn_to_event_streams.rb
+++ b/db/migrate/20161216132051_add_cn_to_event_streams.rb
@@ -1,0 +1,5 @@
+class AddCnToEventStreams < ActiveRecord::Migration[5.0]
+   def change
+     add_column :event_streams, :lxca_cn, :string
+   end
+ end


### PR DESCRIPTION
Old migraine for LXCA events. For some reason the migrate to add LXCA attributes in the events_streams table was not incorporated into manageiq