### PR TITLE
[XCS-104] Adds structure necessary to support the physical servers icons exhibition

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -1,5 +1,6 @@
 class PhysicalServer < ApplicationRecord
   include NewWithTypeStiMixin
+  include MiqPolicyMixin
   include_concern 'Operations'
 
   acts_as_miq_taggable
@@ -7,12 +8,32 @@ class PhysicalServer < ApplicationRecord
   has_many :firmwares, :foreign_key => "ph_server_uuid", :primary_key => "uuid"
   has_one :host, :foreign_key => "service_tag", :primary_key => "serialNumber"
 
+  VENDOR_TYPES = {
+    # DB            Displayed
+    "lenovo"          => "lenovo",
+    "unknown"         => "Unknown",
+    nil               => "Unknown",
+  }
+
   def name_with_details
     details % {
       :name => name,
     }
   end
 
+  def has_compliance_policies?
+    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "physicalserver_compliance_check")
+    !plist.blank?
+  end
+
+  def health_status
+    self.healthState
+  end
+
+  def label_for_vendor
+   # "lenovo"
+    VENDOR_TYPES[self.vendor]
+  end
 
   def is_refreshable?
     refreshable_status[:show]


### PR DESCRIPTION
Some changes that are needed to enable physical server icons, such as:

- Included MiqPolicyMixin into physical_server model;
- Added three methods: `has_compliance_policies, health_status, label_for_vendor`;

This task is done, as well XCS-20