### PR TITLE
[Migration] Adds Vendor Property to Physical Server

### DIFF
--- a/db/migrate/20170223222437_add_vendor_property_to_physical_server.rb
+++ b/db/migrate/20170223222437_add_vendor_property_to_physical_server.rb
@@ -1,0 +1,5 @@
+class AddVendorPropertyToPhysicalServer < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_servers, :vendor, :string
+  end
+end


### PR DESCRIPTION
Migration to add `vendor` property to give support to the physical server icons