### PR TITLE
[XCS-155] [Migration] Adding physical_server_id property to hardware

### DIFF
--- a/db/migrate/20170313141230_add_physical_server_foreign_key_property_to_hardware.rb
+++ b/db/migrate/20170313141230_add_physical_server_foreign_key_property_to_hardware.rb
@@ -1,0 +1,5 @@
+class AddPhysicalServerForeignKeyPropertyToHardware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :physical_server_id, :string, index: true
+  end
+end


### PR DESCRIPTION
Adding `physical_server_id` property to `hardware` table that will be needed to establish relationship between `PhysicalServer` and `Hardware`.